### PR TITLE
Fix Tailwind v4 CSS setup and normalize React bootstrap

### DIFF
--- a/kiwibit/src/index.css
+++ b/kiwibit/src/index.css
@@ -1,8 +1,11 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
-/* Apenas um teste para o fundo */
+html,
+body,
+#root {
+  min-height: 100%;
+}
+
 body {
-  @apply bg-gray-900 text-white min-h-screen flex items-center justify-center;
+  margin: 0;
 }

--- a/kiwibit/src/main.tsx
+++ b/kiwibit/src/main.tsx
@@ -1,6 +1,10 @@
-import React from "react";
-import { createRoot } from "react-dom/client";
-import App from "./App";
-import "./index.css"; // <- isso precisa existir
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import App from './App'
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)


### PR DESCRIPTION
### Motivation
- Fix local build/runtime errors caused by Tailwind/PostCSS setup so the app renders with expected Tailwind utilities under Vite and can be previewed locally.

### Description
- Replace `src/index.css` Tailwind entry to the v4-compatible import (`@import "tailwindcss"`) and remove the problematic `@apply` usage that produced unknown-utility errors, and add a minimal `min-height` / margin reset to keep the app full-height.
- Normalize the React bootstrap in `src/main.tsx` to the standard `StrictMode` + `./index.css` import pattern to ensure consistent HMR and app initialization under Vite.

### Testing
- Built the production bundle with `npm run build` and it completed successfully.
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and verified the UI rendered by capturing a browser screenshot (Playwright), confirming the app boots and styles load as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b5edaf1f8832da49b6e86111ab247)